### PR TITLE
Add timeout=1 to consume()

### DIFF
--- a/gcn_email/core.py
+++ b/gcn_email/core.py
@@ -91,7 +91,7 @@ def kafka_message_to_email(message):
 def recieve_alerts(consumer):
     table = get_email_notification_subscription_table()
     while True:
-        for message in consumer.consume():
+        for message in consumer.consume(timeout=1):
             topic = message.topic()
             metrics.received.labels(topic).inc()
             recipients = query_and_project_subscribers(table, topic)


### PR DESCRIPTION
This matches the client template that we provide to users.