### PR TITLE
Remove explicit dependency on confluent-kafka

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -558,4 +558,4 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3cc7815874de6e68f2e8a98a4923be429532b50d8a0b36ac608122d8256e72cb"
+content-hash = "1ec7d2a8a55ecf8be5cedab2d52467790941e65955d501cb4c63c5d79f0949a6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ authors = ["Dakota Dutko <dakota.c.dutko@nasa.gov>", "Leo Singer <leo.singer@lig
 [tool.poetry.dependencies]
 backoff = "*"
 boto3 = "*"
-confluent-kafka = ">=2.2.0"  # first working version with aarch64 wheels
 gcn-kafka = "^0.3.3"
 python = "^3.9"
 ratelimit = "*"


### PR DESCRIPTION
gcn-kafka 0.3.3 already depends on the required version of confluent-kafka.