### PR TITLE
Adds a check in the gcn.notices. condition for if the topic is also a voevent

### DIFF
--- a/gcn_email/core.py
+++ b/gcn_email/core.py
@@ -107,9 +107,18 @@ def kafka_message_to_email(message):
             subtype="xml",
         )
     elif topic.startswith("gcn.notices."):
-        valueJson = json.loads(message.value().decode())
-        replace_long_values(valueJson, 512)
-        email_message.set_content(json.dumps(valueJson, indent=4))
+        # New voevent topics (ex: gcn.notices.svom.voevent.grm)
+        if ".voevent." in topic:
+            email_message.add_attachment(
+                message.value(),
+                filename="notice.xml",
+                maintype="application",
+                subtype="xml",
+            )
+        else:
+            valueJson = json.loads(message.value().decode())
+            replace_long_values(valueJson, 512)
+            email_message.set_content(json.dumps(valueJson, indent=4))
     else:
         email_message.add_attachment(
             message.value(),


### PR DESCRIPTION
Fixes an issue that was caused by the service trying to parse new `gcn.notices.svom.voevent.*` topics as JSON